### PR TITLE
Spawn camera when respawn

### DIFF
--- a/zscript/SideScrollerHandler.zc
+++ b/zscript/SideScrollerHandler.zc
@@ -14,7 +14,18 @@ class SideScrollerHandler : EventHandler
 			pmo.SpawnCamera();
 		}
 	}
-
+	
+	
+	override void PlayerRespawned (PlayerEvent e) // spawn camera also when the player respawns
+	{
+		let pmo = SideScrollerPlayer(players[e.PlayerNumber].mo);
+		if (pmo)
+		{
+			// spawn the camera
+			pmo.SpawnCamera();
+		}
+	}
+	
 	// destroy the camera when this level is unloaded
 	// in the case of hub levels, we don't want to spawn extra cameras
 	// when the player returns to this level


### PR DESCRIPTION
I tried your side scroller starter kit, and I've found a bug in multiplayer, whenever the player died, the camera returned to first person view. With this little piece of code, I could solve the problem. If you also think this is correct, I propose it to be added.

Another bug I noticed in multiplayer, for some reason player character stutters - only visually, however other players do not, I have no idea what causes it, maybe it's related to the movement prediction? Or to the camera?